### PR TITLE
構造体の変更

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -3,7 +3,7 @@
 
 // parser main
 
-t_parser        *parser(t_context *ctx);
+void            parser(t_context *ctx);
 void            free_parser(t_parser *args);
 t_parser        *args_init(void);
 int             add_redirect(t_parser *cur_arg, t_token *token);

--- a/include/struct.h
+++ b/include/struct.h
@@ -91,10 +91,11 @@ typedef struct s_env {
 
 typedef struct s_context {
 	// 構造体の総まとめをこの構造体にまとめる
-	t_token	*token_head;
-	t_env	*env_head;
-	int		exit_status;
-	bool	sys_error; // 一応
+	t_token     *token_head;
+	t_parser    *parser_head;
+	t_env	    *env_head;
+	int		    exit_status;
+	bool	    sys_error; // 一応
 }	t_context;
 
 #endif

--- a/src/lexer/lexer_word.c
+++ b/src/lexer/lexer_word.c
@@ -2,13 +2,13 @@
 
 void word(char **line_ptr, char *line, t_token *token, bool space_before)
 {
-    const char *start;
+    char *start;
     char *word;
 
     start = line;
     while (*line && is_word(*line))
         line++;
-    word = strndup(start, line - start);
+    word = ft_strndup(start, line - start);
     if (word == NULL)
         fatal_error("tokenize: word strndup error");
     *line_ptr = line;

--- a/src/main.c
+++ b/src/main.c
@@ -60,8 +60,6 @@ bool check_pipe(t_parser *parser)
 
 void	main_loop(t_context *ctx, char *line)
 {
-	t_parser	*parsed;
-
 	while (1)
 	{
 		line = readline("\033[1;33mminishell$\033[0m ");
@@ -76,12 +74,11 @@ void	main_loop(t_context *ctx, char *line)
 		{
 			add_history(line);
 			lexer(ctx, line);
-			parsed = parser(ctx);
-			// print_parser(parsed);
-			if(check_pipe(parsed))
-				minishell_pipe(parsed, ctx);
+			parser(ctx);
+			if(check_pipe(ctx->parser_head))
+				minishell_pipe(ctx->parser_head, ctx);
 			else
-				minishell_no_pipe(parsed, ctx);
+				minishell_no_pipe(ctx->parser_head, ctx);
 			// print_parser(parsed);
 			delete_tmpfile();
 		}

--- a/src/parser/parser_main.c
+++ b/src/parser/parser_main.c
@@ -82,11 +82,11 @@ void free_parser(t_parser *args)
     }
 }
 
-t_parser *parser(t_context *ctx)
+void    parser(t_context *ctx)
 {
-    t_parser *args;
-    t_parser *args_head;
-    t_token *token;
+    t_parser    *args;
+    t_parser    *args_head;
+    t_token     *token;
 
     args = args_init();
     if (args == NULL)
@@ -101,7 +101,7 @@ t_parser *parser(t_context *ctx)
         if (token != NULL && token->type == TK_PIPE)
             handle_pipe(&args, &token);
     }
-    // print_parser(args_head);
+    ctx->parser_head = args_head;
+//    print_parser(args_head);
     // free_parser(args_head);
-    return (args_head);
 }

--- a/src/redirect/pipe.c
+++ b/src/redirect/pipe.c
@@ -4,7 +4,6 @@
 
 #define SUCESS 1
 
-
 static void child_process(t_parser *tmp_parser, t_pipex *pipe_x, t_context *context, int *status)
 {
     if (tmp_parser->prev != NULL)
@@ -15,7 +14,6 @@ static void child_process(t_parser *tmp_parser, t_pipex *pipe_x, t_context *cont
     setup_heredoc_fd(tmp_parser);
     exec_cmd(tmp_parser, context);
 }
-
 
 static void wait_child_and_close_pipe(t_parser *parser, t_pipex *pipe_x)
 {


### PR DESCRIPTION
構造体にparserを含める

目的：freeでリークしにくくなる、builtinのunsetの時にparserが必要

```
typedef struct s_context {
    // 構造体の総まとめをこの構造体にまとめる
    t_token    *token_head;
    t_env    *env_head;
    int        exit_status;
    bool    sys_error; // 一応
}    t_context;
```
↓
```
typedef struct s_context {
    // 構造体の総まとめをこの構造体にまとめる
    t_token    *token_head;
    t_parser   *parser_head; 🌟ここ追加
    t_env    *env_head;
    int        exit_status;
    bool    sys_error; // 一応
}    t_context;
```

