### PR TITLE
存在しない環境変数をechoしたときの挙動を修正

### DIFF
--- a/src/lexer/expansion_env.c
+++ b/src/lexer/expansion_env.c
@@ -35,9 +35,7 @@ static char *get_env_variable_value(char *data, size_t *i, t_context *ctx)
     char    *env_name;
     char    *env_value;
     size_t  var_len;
-    size_t  start;
 
-    start = *i; // '$' の位置を記録
     var_len = 0;
     (*i)++; // '$' を消費
     while (data[*i + var_len] && is_env_name_char(data[*i + var_len]))
@@ -47,7 +45,7 @@ static char *get_env_variable_value(char *data, size_t *i, t_context *ctx)
         fatal_error("Expansion: ft_substr failed");
     env_value = get_env_value(env_name, ctx->env_head);
     if (!env_value) // 環境変数が見つからない場合、元の文字列を返す
-        env_value = ft_substr(data, start, var_len + 1); // '+1' は '$' の分
+        env_value = ft_strdup("");
     else
         env_value = ft_strdup(env_value);
     if (!env_value)


### PR DESCRIPTION
https://github.com/hayasesou/minishell/issues/31#issue-2580435502

test 
1. minishell$echo $aaaaaaaaaaaaaaaaaaaaaaaaaa
2. minishell$echo "$aaaaaaaaaaaaaaaaaaaaa"