### PR TITLE
resolve single << or >> or < or >

### DIFF
--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -1,5 +1,29 @@
 #include "minishell.h"
 
+void	check_token_operation(t_context *ctx)
+{
+	t_token	*current;
+
+	current = ctx->token_head;
+	while (current->type != TK_EOF)
+	{
+		if ((current->type == TK_REDIR_IN
+				|| current->type == TK_REDIR_OUT
+				|| current->type == TK_REDIR_APPEND
+				|| current->type == TK_REDIR_HEREDOC
+				|| current->type == TK_PIPE)
+			&& current->next->type == TK_EOF)
+		{
+			free_token(&ctx->token_head);
+			ft_printf("syntax error near unexpected token `newline'\n");
+			ctx->exit_status = 2;
+			ctx->token_head = NULL;
+			return ;
+		}
+		current = current->next;
+	}
+}
+
 void lexer(t_context *ctx, char *line)
 {
     t_token *token;
@@ -40,6 +64,9 @@ void lexer(t_context *ctx, char *line)
             token = token->next;
     }
     token_node_add(token, token_node_create("", TK_EOF));
+	check_token_operation(ctx);
+	if (ctx->token_head == NULL)
+		return ;
     expansion(token_head,  ctx);
 //    printf("\n----------- lexer start-------------\n");
 //    print_lexer(token_head);


### PR DESCRIPTION
https://github.com/hayasesou/minishell/issues/29#issue-2579154818

test:
minishell$<<
or
minishell$<
or
minishell$>
or
minishell$>>

ideal behavior:
syntax error near unexpected token `newline`


他のテストしてください