### PR TITLE
Feature/hakobaya/exi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OBJS = $(addprefix $(OBJDIR)/, $(FILES:.c=.o)) \
 	   $(addprefix $(OBJDIR)/, $(BUILTIN_FILES:.c=.o)) \
 	   $(addprefix $(OBJDIR)/, $(SIGNAL_FILES:.c=.o))
 
-FILES = main.c env.c error.c env_utils.c free_all.c
+FILES = main.c env.c error.c env_utils.c free_all.c free_utils.c
 LEXER_FILES = $(notdir $(wildcard $(LEXERDIR)/*.c))
 PARSER_FILES =	$(notdir $(wildcard $(PARSERDIR)/*.c))
 REDIRECT_FILES = $(notdir $(wildcard $(REDIRECTDIR)/*.c))

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -38,5 +38,10 @@ void	unset_builtin(t_parser *parser, t_context *context);
 
 //builtin_exit.c
 void	exit_builtin(t_parser *parser, t_context *context, bool is_parent);
+void    ft_puterr(char *str);
+bool    overflow_check(long num, int num2, int flag);
+bool    is_overflow(char *str);
+bool    is_valid_number(const char *str);
+void	cleanup_and_exit(t_context *context, int exit_status);
 
 #endif

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -5,11 +5,11 @@
 #include "minishell.h"
 
 //builtin.c
-void	exec_cmd(t_parser *parser, t_context *context);
+void	exec_cmd(t_parser *parser, t_context *context, bool is_parent);
 
 //builtin_minishell.c
 bool	is_minishell_builtin(char *cmd);
-void	exec_minishell_builtin(t_parser *parser, t_context *context, char *cmd);
+void	exec_minishell_builtin(t_parser *parser, t_context *context, char *cmd, bool is_parent);
 
 //builtin_bash.c
 void	bash_builtin(t_parser *parser, t_context *context);
@@ -35,5 +35,8 @@ void	env_builtin(t_parser *parser, t_context *context);
 
 //builtin_unset.c
 void	unset_builtin(t_parser *parser, t_context *context);
+
+//builtin_exit.c
+void	exit_builtin(t_parser *parser, t_context *context, bool is_parent);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -30,6 +30,7 @@
 //exit_status
 # define NORMAL_EXIT 0
 # define NORMAL_ERROR 1
+# define NUMERIC_ERROR 255
 # define ERROR_TOKENIZE 258
 # define COMMAND_NOT_FOUND 127
 # define PERMISSION_DENIED 126

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -69,11 +69,10 @@ void    signal_init(t_context *ctx);
 void    set_signal_handler();
 void	set_signal_parent_handler();
 void    set_signal_child_handler();
-void    set_heredoc_signal_parent_handler();
-void    set_heredoc_signal_child_handler();
+void    set_heredoc_signal_handler();
 void	signal_handler(int signum);
 void    signal_parent_handler(int signum);
-void	heredoc_signal_parent_handler(int signum);
+void	heredoc_signal_handler(int signum);
 
 // free
 void    free_token(t_token **head);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -81,6 +81,7 @@ void    free_parser(t_parser **head);
 void    free_env_node(t_env *node);
 void    free_env(t_env *head);
 void    free_all(t_context *ctx);
+void    free_cmd(char **cmd);
 
 // main
 void	main_loop(t_context *ctx, char *line);

--- a/include/struct.h
+++ b/include/struct.h
@@ -98,6 +98,11 @@ typedef struct s_env {
 	t_env	*prev;
 }	t_env;
 
+typedef enum	e_process_type {
+	PARENT,
+	CHILD
+}	t_process_type;
+
 typedef struct s_context {
 	// 構造体の総まとめをこの構造体にまとめる
 	t_token     *token_head;

--- a/src/builtin/builtin_bash.c
+++ b/src/builtin/builtin_bash.c
@@ -109,6 +109,8 @@ void	bash_builtin(t_parser *parser, t_context *context)
 		free(path);
 		return ;
 	}
+	if (path == NULL)
+		return ;
 	while (path[i] != '\0')
 	{
 		if (path[i] == ':')

--- a/src/builtin/builtin_minishell.c
+++ b/src/builtin/builtin_minishell.c
@@ -28,7 +28,7 @@ bool	is_minishell_builtin(char *cmd)
 }
 
 //todo: implement self_builtin
-void	exec_minishell_builtin(t_parser *parser, t_context *context, char *cmd)
+void	exec_minishell_builtin(t_parser *parser, t_context *context, char *cmd, bool is_parent)
 {
 	if (ft_strncmp(cmd, "echo", ft_strlen("echo")) == 0
 		&& (ft_strlen(cmd) == ft_strlen("echo")))
@@ -50,5 +50,5 @@ void	exec_minishell_builtin(t_parser *parser, t_context *context, char *cmd)
 		env_builtin(parser, context);
 	else if (ft_strncmp(cmd, "exit", ft_strlen("exit")) == 0
 		&& (ft_strlen(cmd) == ft_strlen("exit")))
-		exit_builtin(parser, context);
+		exit_builtin(parser, context, is_parent);
 }

--- a/src/builtin/builtin_minishell.c
+++ b/src/builtin/builtin_minishell.c
@@ -50,5 +50,5 @@ void	exec_minishell_builtin(t_parser *parser, t_context *context, char *cmd)
 		env_builtin(parser, context);
 	else if (ft_strncmp(cmd, "exit", ft_strlen("exit")) == 0
 		&& (ft_strlen(cmd) == ft_strlen("exit")))
-		return ;
+		exit_builtin(parser, context);
 }

--- a/src/builtin/exec_main.c
+++ b/src/builtin/exec_main.c
@@ -1,6 +1,6 @@
 #include "minishell.h"
 
-void	exec_cmd(t_parser *parser, t_context *context)
+void	exec_cmd(t_parser *parser, t_context *context, bool is_parent)
 {
 	if (parser->cmd == NULL)
 	{
@@ -10,7 +10,7 @@ void	exec_cmd(t_parser *parser, t_context *context)
 	}
 	if (is_minishell_builtin(parser->cmd[0]) == true)
 	{
-		exec_minishell_builtin(parser, context, parser->cmd[0]);
+		exec_minishell_builtin(parser, context, parser->cmd[0], is_parent);
 		exit(EXIT_SUCCESS);
 	}
 	else

--- a/src/builtin/exit_builtin.c
+++ b/src/builtin/exit_builtin.c
@@ -5,17 +5,26 @@ void ft_puterr(char *str)
     write(2, str, ft_strlen(str));
 }
 
-bool is_overflow(const char *str)
+static bool overflow_check(long num, int num2, int flag)
 {
-    size_t	len;
-	size_t	num;
+    if ((num * flag > LONG_MAX / 10) || (num * flag == LONG_MAX / 10 && num2 > LONG_MAX % 10))
+        return (true);
+    if ((num * flag < LONG_MIN / 10) || (num * flag == LONG_MIN / 10 && num2 > -1 * (LONG_MIN % 10)))
+        return (true);
+    return (false);
+}
+
+bool is_overflow(char *str)
+{
+	long	num;
 	int		flag;
 
-	len = ft_strlen(str);
-	if (len > 19) // 緩いかも
-		return (false);
 	num = 0;
 	flag = 1;
+    while (*str == ' ')
+    {
+        str++;
+    }
 	if (*str == '+' || *str == '-')
 	{
 		if (*str == '-')
@@ -24,12 +33,12 @@ bool is_overflow(const char *str)
 	}
 	while (ft_isdigit(*str))
 	{
+        if (overflow_check(num, *str - '0', flag))
+            return (true);
 		num = (num * 10) + (*str - '0');
 		str++;
 	}
-	if ((num > LONG_MAX && flag == 1) || (num - 1 > LONG_MAX && flag == -1))
-		return (false);
-	return (true);
+    return (false);
 }
 
 bool is_valid_number(const char *str)
@@ -113,7 +122,7 @@ void    exit_space(char **cmd, char **new_cmd, t_context *context)
 void    exit_main(char **cmd, t_context *context)
 {
 
-    if (!is_valid_number(cmd[1]))
+    if (!is_valid_number(cmd[1]) || is_overflow(cmd[1]))
     {
         print_numeric_error(context, cmd[1]);
         cleanup_and_exit(context, 255);

--- a/src/builtin/exit_builtin.c
+++ b/src/builtin/exit_builtin.c
@@ -1,5 +1,69 @@
 #include "minishell.h"
 
+// 引数として渡された文字列がlongの範囲内かどうかを判定する関数
+static bool	is_overflow(char *str)
+{
+	size_t	len;
+	size_t	num;
+	int		flag;
+
+	len = ft_strlen(str);
+	if (len > -214748648) // LONG_MINに変更する
+		return (false);
+	num = 0;
+	flag = 1;
+	if (*str == '+' || *str == '-')
+	{
+		if (*str == '-')
+			flag *= -1;
+		str++;
+	}
+	while (ft_isdigit(*str))
+	{
+		num = (num * 10) + (*str - '0');
+		str++;
+	}
+	if ((num > LONG_MAX && flag == 1) || (num - 1 > LONG_MAX && flag == -1))
+		return (false);
+	return (true);
+}
+
+static bool	is_numeric(char *str)
+{
+	size_t	i;
+
+	i = 0;
+	if (str[0] == '-' || str[0] == '+')
+		i++;
+	while (str[i])
+	{
+		if (!ft_isdigit(str[i]))
+		{
+			return (false);
+		}
+		i++;
+	}
+	return (true);
+}
+
+static void	numeric_error(char *status)
+{
+	ft_printf("minishell: exit: ");
+	ft_printf("%s: ", status);
+	ft_printf("numeric argument required\n");
+}
+
+static void	too_many_error(void)
+{
+	ft_printf("minishell: exit: ");
+	ft_printf("too many arguments\n");
+}
+
+void    ft_puterr(char *str)
+{
+    write(2, str, ft_strlen(str));
+}
+
 static void    exit_with_error(char *msg, int exit_code, char **args, t_context *ctx)
 {
     ft_puterr("exit\n");
@@ -11,8 +75,60 @@ static void    exit_with_error(char *msg, int exit_code, char **args, t_context 
     exit(exit_code);
 }
 
-void    exit_builtin()
+void    exit_builtin(t_parser *parser, t_context *context, t_process_type type)
 {
+    int     args_count;
+    char    **cmd;
+
+    args_count = 0;
+    cmd = parser->cmd;
+    if (cmd[1] == NULL || !ft_strcmp("--", cmd[1]))
+    {
+        free_all(context);
+        if (type == PARENT)
+            exit(context->exit_status);
+        else
+            exit(0);
+    }
+    while (cmd[args_count])
+        args_count++;
+    if (args_count == 1)
+    {
+        ft_printf("exit\n");
+        free_all(context);
+        exit(context->exit_status);
+    }
+    else if (args_count == 2)
+    {
+        if (!ft_isdigit(cmd[1][0]))
+            exit_with_error("numeric argument required", ERROR_TOKENIZE, cmd, context);
+        ft_printf("exit\n");
+        free_all(context);
+        exit(ft_atoi(cmd[1]));
+    }
+    else
+    if (args_count > 2)
+        exit_with_error("too many arguments", NORMAL_ERROR, cmd, ctx);
     ft_printf("exit\n");
     exit(0);
 }
+
+// 引数なし (exit):
+
+// シェルを終了させます。
+// 終了時のステータスコードとして、シェルが最後に実行したコマンドの終了ステータス (exit_status) を使用します。
+// 通常、シェルが正常に動作している場合は 0 です。
+// 数値引数あり (exit 42):
+
+// 指定された数値 (42 など) をステータスコードとしてシェルを終了させます。
+// ステータスコードは 0 から 255 の範囲内で使用されます。
+// 数値が範囲外の場合、256 で割った余りがステータスコードとして使用されます（例：exit 256 は 0 として終了）。
+// エラーケース:
+
+// 数値以外の引数が指定された場合:
+// エラーメッセージを表示し、ステータスコード 255 で終了します。
+// 例: exit abc → エラーメッセージを表示して 255 で終了。
+// 複数の引数が指定された場合:
+// エラーメッセージを表示し、シェルは終了しません。
+// ステータスコードは 1 に設定されます。
+// 例: exit 1 2 → エラーメッセージを表示して 1 に設定。

--- a/src/builtin/exit_builtin.c
+++ b/src/builtin/exit_builtin.c
@@ -1,134 +1,132 @@
 #include "minishell.h"
 
-// 引数として渡された文字列がlongの範囲内かどうかを判定する関数
-static bool	is_overflow(char *str)
-{
-	size_t	len;
-	size_t	num;
-	int		flag;
-
-	len = ft_strlen(str);
-	if (len > -214748648) // LONG_MINに変更する
-		return (false);
-	num = 0;
-	flag = 1;
-	if (*str == '+' || *str == '-')
-	{
-		if (*str == '-')
-			flag *= -1;
-		str++;
-	}
-	while (ft_isdigit(*str))
-	{
-		num = (num * 10) + (*str - '0');
-		str++;
-	}
-	if ((num > LONG_MAX && flag == 1) || (num - 1 > LONG_MAX && flag == -1))
-		return (false);
-	return (true);
-}
-
-static bool	is_numeric(char *str)
-{
-	size_t	i;
-
-	i = 0;
-	if (str[0] == '-' || str[0] == '+')
-		i++;
-	while (str[i])
-	{
-		if (!ft_isdigit(str[i]))
-		{
-			return (false);
-		}
-		i++;
-	}
-	return (true);
-}
-
-static void	numeric_error(char *status)
-{
-	ft_printf("minishell: exit: ");
-	ft_printf("%s: ", status);
-	ft_printf("numeric argument required\n");
-}
-
-static void	too_many_error(void)
-{
-	ft_printf("minishell: exit: ");
-	ft_printf("too many arguments\n");
-}
-
-void    ft_puterr(char *str)
+void ft_puterr(char *str)
 {
     write(2, str, ft_strlen(str));
 }
 
-static void    exit_with_error(char *msg, int exit_code, char **args, t_context *ctx)
+bool is_overflow(const char *str, long *result)
 {
-    ft_puterr("exit\n");
+    int i;
+    int sign;
+    unsigned long num;
+    unsigned long cutoff;
+    int cutlim;
+
+    i = 0;
+    sign = 1;
+    num = 0;
+    if (str[i] == '+' || str[i] == '-')
+    {
+        if (str[i] == '-')
+            sign = -1;
+        i++;
+    }
+    if (sign == -1)
+        cutoff = -(unsigned long)LONG_MIN;
+    else
+        cutoff = LONG_MAX;
+    cutlim = cutoff % 10;
+    cutoff /= 10;
+    while (str[i])
+    {
+        int c = str[i++] - '0';
+
+        if (num > cutoff || (num == cutoff && c > cutlim))
+            return true;
+
+        num = num * 10 + c;
+    }
+    if (sign == -1)
+        *result = -(long)num;
+    else
+        *result = (long)num;
+
+    return false;
+}
+
+bool is_valid_number(const char *str)
+{
+    int i = 0;
+
+    if (str[i] == '\0')
+        return (false);
+    if (str[i] == '+' || str[i] == '-')
+        i++;
+    if (str[i] == '\0') // 符号のみの場合
+        return (false);
+    while (str[i])
+    {
+        if (!ft_isdigit(str[i]))
+            return (false);
+        i++;
+    }
+    return (true);
+}
+
+
+static void	print_numeric_error(char *status, bool is_parent)
+{
+    if (is_parent)
+        ft_puterr("minishell: exit: ");
     ft_puterr("minishell: exit: ");
-    ft_puterr(msg);
-    ft_puterr("\n");
-    free_all(ctx);
-    ctx->exit_status = exit_code;
+    ft_puterr(status);
+    ft_puterr(": numeric argument required\n");
+}
+
+static void	print_too_many_args(bool is_parent)
+{
+    if (is_parent)
+        ft_puterr("exit\n");
+    ft_puterr("minishell: exit: too many arguments\n");
+}
+
+static void	cleanup_and_exit(t_context *context, int exit_code)
+{
+    free_all(context);
     exit(exit_code);
 }
 
-void    exit_builtin(t_parser *parser, t_context *context, t_process_type type)
+void    exit_builtin(t_parser *parser, t_context *context)
 {
-    int     args_count;
     char    **cmd;
+    long    exit_code;
+    int     final_exit_code;
+    bool    is_parent;
+    pid_t   pid;
 
-    args_count = 0;
-    cmd = parser->cmd;
-    if (cmd[1] == NULL || !ft_strcmp("--", cmd[1]))
-    {
-        free_all(context);
-        if (type == PARENT)
-            exit(context->exit_status);
-        else
-            exit(0);
-    }
-    while (cmd[args_count])
-        args_count++;
-    if (args_count == 1)
-    {
-        ft_printf("exit\n");
-        free_all(context);
-        exit(context->exit_status);
-    }
-    else if (args_count == 2)
-    {
-        if (!ft_isdigit(cmd[1][0]))
-            exit_with_error("numeric argument required", ERROR_TOKENIZE, cmd, context);
-        ft_printf("exit\n");
-        free_all(context);
-        exit(ft_atoi(cmd[1]));
-    }
+    pid = getpid();
+    if (pid == 0)
+        is_parent = false;
     else
-    if (args_count > 2)
-        exit_with_error("too many arguments", NORMAL_ERROR, cmd, ctx);
-    ft_printf("exit\n");
-    exit(0);
+        is_parent = true;
+    cmd = parser->cmd;
+    exit_code = 0;
+    if (cmd[1] == NULL)
+    {
+        if (is_parent)
+            ft_puterr("exit\n");
+        cleanup_and_exit(context, context->exit_status);
+    }
+
+    if (!is_valid_number(cmd[1]) || is_overflow(cmd[1], &exit_code))
+    {
+        print_numeric_error(cmd[1], is_parent);
+        cleanup_and_exit(context, 255);
+    }
+    
+    if (cmd[2] != NULL)
+    {
+        print_too_many_args(is_parent);
+        context->exit_status = 1;
+        return; // シェルを終了させないらしい
+    }
+    final_exit_code = (int)(exit_code % 256);
+    if (final_exit_code < 0)
+        final_exit_code += 256;
+
+    if (is_parent)
+        ft_puterr("exit\n");
+
+    cleanup_and_exit(context, final_exit_code);
 }
-
-// 引数なし (exit):
-
-// シェルを終了させます。
-// 終了時のステータスコードとして、シェルが最後に実行したコマンドの終了ステータス (exit_status) を使用します。
-// 通常、シェルが正常に動作している場合は 0 です。
-// 数値引数あり (exit 42):
-
-// 指定された数値 (42 など) をステータスコードとしてシェルを終了させます。
-// ステータスコードは 0 から 255 の範囲内で使用されます。
-// 数値が範囲外の場合、256 で割った余りがステータスコードとして使用されます（例：exit 256 は 0 として終了）。
-// エラーケース:
-
-// 数値以外の引数が指定された場合:
-// エラーメッセージを表示し、ステータスコード 255 で終了します。
-// 例: exit abc → エラーメッセージを表示して 255 で終了。
-// 複数の引数が指定された場合:
-// エラーメッセージを表示し、シェルは終了しません。
-// ステータスコードは 1 に設定されます。
-// 例: exit 1 2 → エラーメッセージを表示して 1 に設定。

--- a/src/builtin/exit_builtin.c
+++ b/src/builtin/exit_builtin.c
@@ -2,18 +2,18 @@
 
 static void	print_numeric_error(t_context *context, char *str)
 {
-    ft_puterr("minishell: exit: ");
-    ft_puterr(str);
-    ft_puterr(": numeric argument required\n");
+    ft_putstr_fd("minishell: exit: ", 2);
+    ft_putstr_fd(str, 2);
+    ft_putstr_fd(": numeric argument required\n", 2);
     free_env(context->env_head);
-    context->exit_status = 255;
-    exit(255);
+    context->exit_status = NUMERIC_ERROR;
+    exit(NUMERIC_ERROR);
 }
 
 static void	print_too_many_args(t_context *context)
 {
-    ft_puterr("minishell: exit: too many arguments\n");
-    context->exit_status = 1;
+    ft_putstr_fd("minishell: exit: too many arguments\n", 2);
+    context->exit_status = NORMAL_ERROR;
 }
 
 void    exit_space(char **cmd, char **new_cmd, t_context *context)
@@ -38,7 +38,7 @@ void    exit_main(char **cmd, t_context *context)
     if (!is_valid_number(cmd[1]) || is_overflow(cmd[1]))
     {
         print_numeric_error(context, cmd[1]);
-        cleanup_and_exit(context, 255);
+        cleanup_and_exit(context, NUMERIC_ERROR);
     }
     if (cmd[2] != NULL)
         print_too_many_args(context); // ここexitしないでOK？
@@ -53,7 +53,7 @@ void    exit_builtin(t_parser *parser, t_context *context, bool is_parent)
 
     cmd = parser->cmd;
     if (is_parent)
-        ft_puterr("exit\n");
+        ft_putstr_fd("exit\n", 1);
     if (cmd[1] == NULL || !ft_strncmp("--", cmd[1], 2))
         cleanup_and_exit(context, context->exit_status);
     if (ft_strchr(cmd[1], ' '))

--- a/src/builtin/exit_builtin.c
+++ b/src/builtin/exit_builtin.c
@@ -12,7 +12,7 @@ bool is_overflow(const char *str)
 	int		flag;
 
 	len = ft_strlen(str);
-	if (len > 20)
+	if (len > 19) // 緩いかも
 		return (false);
 	num = 0;
 	flag = 1;

--- a/src/builtin/exit_builtin.c
+++ b/src/builtin/exit_builtin.c
@@ -1,69 +1,5 @@
 #include "minishell.h"
 
-void ft_puterr(char *str)
-{
-    write(2, str, ft_strlen(str));
-}
-
-static bool overflow_check(long num, int num2, int flag)
-{
-    if ((num * flag > LONG_MAX / 10) || (num * flag == LONG_MAX / 10 && num2 > LONG_MAX % 10))
-        return (true);
-    if ((num * flag < LONG_MIN / 10) || (num * flag == LONG_MIN / 10 && num2 > -1 * (LONG_MIN % 10)))
-        return (true);
-    return (false);
-}
-
-bool is_overflow(char *str)
-{
-	long	num;
-	int		flag;
-
-	num = 0;
-	flag = 1;
-    while (*str == ' ')
-    {
-        str++;
-    }
-	if (*str == '+' || *str == '-')
-	{
-		if (*str == '-')
-			flag *= -1;
-		str++;
-	}
-	while (ft_isdigit(*str))
-	{
-        if (overflow_check(num, *str - '0', flag))
-            return (true);
-		num = (num * 10) + (*str - '0');
-		str++;
-	}
-    return (false);
-}
-
-bool is_valid_number(const char *str)
-{
-    int i;
-
-    i = 0;
-    if (str == NULL)
-        return (false);
-    if (str[i] == '\0')
-        return (false);
-    if (str[i] == '+' || str[i] == '-')
-        i++;
-    while (str[i])
-    {
-        if (!ft_isdigit(str[i]))
-            return (false);
-        i++;
-    }
-    if (str[i] == '\0')
-        return (true);
-    else
-        return (false);
-}
-
 static void	print_numeric_error(t_context *context, char *str)
 {
     ft_puterr("minishell: exit: ");
@@ -78,29 +14,6 @@ static void	print_too_many_args(t_context *context)
 {
     ft_puterr("minishell: exit: too many arguments\n");
     context->exit_status = 1;
-}
-
-static void	cleanup_and_exit(t_context *context, int exit_status)
-{
-    free_all(context);
-    exit(exit_status);
-}
-
-void    free_cmd(char **cmd)
-{
-    size_t	i;
-
-	i = 0;
-	if (cmd == NULL)
-		return ;
-	while (cmd[i])
-	{
-		free(cmd[i]);
-		cmd[i] = NULL;
-		i++;
-	}
-	free(cmd);
-	cmd = NULL;
 }
 
 void    exit_space(char **cmd, char **new_cmd, t_context *context)

--- a/src/builtin/exit_builtin.c
+++ b/src/builtin/exit_builtin.c
@@ -1,0 +1,18 @@
+#include "minishell.h"
+
+static void    exit_with_error(char *msg, int exit_code, char **args, t_context *ctx)
+{
+    ft_puterr("exit\n");
+    ft_puterr("minishell: exit: ");
+    ft_puterr(msg);
+    ft_puterr("\n");
+    free_all(ctx);
+    ctx->exit_status = exit_code;
+    exit(exit_code);
+}
+
+void    exit_builtin()
+{
+    ft_printf("exit\n");
+    exit(0);
+}

--- a/src/builtin/exit_builtin_utils.c
+++ b/src/builtin/exit_builtin_utils.c
@@ -1,0 +1,71 @@
+#include "minishell.h"
+
+void ft_puterr(char *str)
+{
+    write(2, str, ft_strlen(str));
+}
+
+bool overflow_check(long num, int num2, int flag)
+{
+    if ((num * flag > LONG_MAX / 10) || (num * flag == LONG_MAX / 10 && num2 > LONG_MAX % 10))
+        return (true);
+    if ((num * flag < LONG_MIN / 10) || (num * flag == LONG_MIN / 10 && num2 > -1 * (LONG_MIN % 10)))
+        return (true);
+    return (false);
+}
+
+bool is_overflow(char *str)
+{
+	long	num;
+	int		flag;
+
+	num = 0;
+	flag = 1;
+    while (*str == ' ')
+    {
+        str++;
+    }
+	if (*str == '+' || *str == '-')
+	{
+		if (*str == '-')
+			flag *= -1;
+		str++;
+	}
+	while (ft_isdigit(*str))
+	{
+        if (overflow_check(num, *str - '0', flag))
+            return (true);
+		num = (num * 10) + (*str - '0');
+		str++;
+	}
+    return (false);
+}
+
+bool is_valid_number(const char *str)
+{
+    int i;
+
+    i = 0;
+    if (str == NULL)
+        return (false);
+    if (str[i] == '\0')
+        return (false);
+    if (str[i] == '+' || str[i] == '-')
+        i++;
+    while (str[i])
+    {
+        if (!ft_isdigit(str[i]))
+            return (false);
+        i++;
+    }
+    if (str[i] == '\0')
+        return (true);
+    else
+        return (false);
+}
+
+void	cleanup_and_exit(t_context *context, int exit_status)
+{
+    free_all(context);
+    exit(exit_status);
+}

--- a/src/builtin/exit_builtin_utils.c
+++ b/src/builtin/exit_builtin_utils.c
@@ -1,8 +1,8 @@
 #include "minishell.h"
 
-void ft_puterr(char *str)
+void ft_putstr_fd(char *str, int fd)
 {
-    write(2, str, ft_strlen(str));
+    write(fd, str, ft_strlen(str));
 }
 
 bool overflow_check(long num, int num2, int flag)

--- a/src/free_all.c
+++ b/src/free_all.c
@@ -67,35 +67,6 @@ void free_parser(t_parser **head_ref)
 	*head_ref = NULL;
 }
 
-void free_env_node(t_env *node)
-{
-	if (node == NULL)
-		return ;
-	free(node->env_name);
-	node->env_name = NULL;
-	free(node->env_val);
-	node->env_val = NULL;
-	free(node);
-	node = NULL;
-}
-
-void free_env(t_env *head)
-{
-    t_env	*cur;
-    t_env	*next;
-
-	cur = head->next;
-    if (head == NULL)
-        return;
-    while (cur != head)
-    {
-        next = cur->next;
-        free_env_node(cur);
-        cur = next;
-    }
-    free_env_node(head);
-}
-
 void free_all(t_context *ctx)
 {
     if (ctx == NULL)
@@ -117,9 +88,3 @@ void free_all(t_context *ctx)
     }
     free(ctx);
 }
-
-// void    exit_free(t_context *ctx)
-// {
-//     free_all(ctx);
-//     exit(1);
-// }

--- a/src/free_utils.c
+++ b/src/free_utils.c
@@ -1,0 +1,47 @@
+#include "minishell.h"
+
+void    free_cmd(char **cmd)
+{
+    size_t	i;
+
+	i = 0;
+	if (cmd == NULL)
+		return ;
+	while (cmd[i])
+	{
+		free(cmd[i]);
+		cmd[i] = NULL;
+		i++;
+	}
+	free(cmd);
+	cmd = NULL;
+}
+
+void    free_env_node(t_env *node)
+{
+	if (node == NULL)
+		return ;
+	free(node->env_name);
+	node->env_name = NULL;
+	free(node->env_val);
+	node->env_val = NULL;
+	free(node);
+	node = NULL;
+}
+
+void    free_env(t_env *head)
+{
+    t_env	*cur;
+    t_env	*next;
+
+	cur = head->next;
+    if (head == NULL)
+        return;
+    while (cur != head)
+    {
+        next = cur->next;
+        free_env_node(cur);
+        cur = next;
+    }
+    free_env_node(head);
+}

--- a/src/lexer/expansion_env.c
+++ b/src/lexer/expansion_env.c
@@ -35,9 +35,7 @@ static char *get_env_variable_value(char *data, size_t *i, t_context *ctx)
     char    *env_name;
     char    *env_value;
     size_t  var_len;
-    size_t  start;
 
-    start = *i; // '$' の位置を記録
     var_len = 0;
     (*i)++; // '$' を消費
     while (data[*i + var_len] && is_env_name_char(data[*i + var_len]))
@@ -47,7 +45,7 @@ static char *get_env_variable_value(char *data, size_t *i, t_context *ctx)
         fatal_error("Expansion: ft_substr failed");
     env_value = get_env_value(env_name, ctx->env_head);
     if (!env_value) // 環境変数が見つからない場合、元の文字列を返す
-        env_value = ft_substr(data, start, var_len + 1); // '+1' は '$' の分
+        env_value = ft_strdup("");
     else
         env_value = ft_strdup(env_value);
     if (!env_value)

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -1,5 +1,29 @@
 #include "minishell.h"
 
+void	check_token_operation(t_context *ctx)
+{
+	t_token	*current;
+
+	current = ctx->token_head;
+	while (current->type != TK_EOF)
+	{
+		if ((current->type == TK_REDIR_IN
+				|| current->type == TK_REDIR_OUT
+				|| current->type == TK_REDIR_APPEND
+				|| current->type == TK_REDIR_HEREDOC
+				|| current->type == TK_PIPE)
+			&& current->next->type == TK_EOF)
+		{
+			free_token(&ctx->token_head);
+			ft_printf("syntax error near unexpected token `newline'\n");
+			ctx->exit_status = 2;
+			ctx->token_head = NULL;
+			return ;
+		}
+		current = current->next;
+	}
+}
+
 void lexer(t_context *ctx, char *line)
 {
     t_token *token;
@@ -40,6 +64,9 @@ void lexer(t_context *ctx, char *line)
             token = token->next;
     }
     token_node_add(token, token_node_create("", TK_EOF));
+	check_token_operation(ctx);
+	if (ctx->token_head == NULL)
+		return ;
     expansion(token_head,  ctx);
 //    printf("\n----------- lexer start-------------\n");
 //    print_lexer(token_head);

--- a/src/main.c
+++ b/src/main.c
@@ -121,7 +121,7 @@ int	main(int ac, char **av, char **envp)
 	char	*line;
 	t_context	*ctx;
 
-	rl_outstream = stderr;
+	// rl_outstream = stderr; //なんで設定したっけ、stdoutじゃなくていいの？
 	status = 0;
 	ctx = minishell_init(ac, av, envp);
 	if (ctx == NULL)

--- a/src/main.c
+++ b/src/main.c
@@ -82,7 +82,6 @@ void main_exec(char *line, t_context *ctx)
 	parser(ctx);
 	free_token(&ctx->token_head);
 	ctx->token_head = NULL;
-	// print_parser(ctx->parser_head);
 	if (ctx->parser_head == NULL)
 		return ;
 	if(check_pipe(ctx->parser_head))

--- a/src/main.c
+++ b/src/main.c
@@ -35,9 +35,11 @@ void minishell_no_pipe(t_parser *parser, t_context *context)
 		return ;
 	if(is_minishell_builtin(parser->cmd[0]))
 	{
+		set_signal_parent_handler();
 		process_heredoc(parser, context, &status);
 		builtin_redirect(parser, context, &status);
-		exec_minishell_builtin(parser, context, parser->cmd[0]);
+		exec_minishell_builtin(parser, context, parser->cmd[0], true);
+		set_signal_handler();
 	}
 	else
 	{
@@ -49,7 +51,7 @@ void minishell_no_pipe(t_parser *parser, t_context *context)
 			process_heredoc(parser, context, &status);
 			redirect(parser, context, &status);
 			setup_heredoc_fd(parser);
-			exec_cmd(parser, context);
+			exec_cmd(parser, context, false);
 		}
 		else
 		{

--- a/src/main.c
+++ b/src/main.c
@@ -117,11 +117,10 @@ void	main_loop(t_context *ctx, char *line)
 
 int	main(int ac, char **av, char **envp)
 {
-	int		status;
-	char	*line;
+	int			status;
+	char		*line;
 	t_context	*ctx;
 
-	// rl_outstream = stderr; //なんで設定したっけ、stdoutじゃなくていいの？
 	status = 0;
 	ctx = minishell_init(ac, av, envp);
 	if (ctx == NULL)

--- a/src/redirect/heredoc.c
+++ b/src/redirect/heredoc.c
@@ -1,5 +1,4 @@
 #include "minishell.h"
-
 static	int	heredoc_readline(char **line,
 	t_heredoc *heredoc, t_context *context, int *heredoc_status)
 {
@@ -32,7 +31,7 @@ int	heredoc(t_file *file, t_context *context, int *heredoc_status)
 	t_heredoc	heredoc;
 	char		*line;
 
-	set_heredoc_signal_parent_handler();
+	set_heredoc_signal_handler();
 	heredoc.deliminater = file->filename;
 	create_tmpfile(&heredoc, context, heredoc_status);
 	while (1)
@@ -40,6 +39,7 @@ int	heredoc(t_file *file, t_context *context, int *heredoc_status)
 		if (heredoc_readline(&line, &heredoc, context, heredoc_status) == 1)
 			break ;
 	}
+	set_signal_handler();
 	close(heredoc.tmpfile_fd);
 	heredoc.tmpfile_fd = open(heredoc.tmpfile, O_RDONLY);
 	free(heredoc.tmpfile);
@@ -79,7 +79,7 @@ int	quote_heredoc(t_file *file, t_context *context, int *heredoc_status)
 	t_heredoc	heredoc;
 	char		*line;
 
-	set_heredoc_signal_parent_handler();
+	set_heredoc_signal_handler();
 	heredoc.deliminater = file->filename;
 	create_tmpfile(&heredoc, context, heredoc_status);
 	while (1)

--- a/src/redirect/pipe.c
+++ b/src/redirect/pipe.c
@@ -12,7 +12,7 @@ static	void	child_process(t_parser *tmp_parser,
 		next_pipe(pipe_x, pipe_x->current_cmd_num);
 	redirect(tmp_parser, context, status);
 	setup_heredoc_fd(tmp_parser);
-	exec_cmd(tmp_parser, context);
+	exec_cmd(tmp_parser, context, false);
 }
 
 
@@ -46,7 +46,7 @@ void	minishell_pipe(t_parser *parser_head, t_context *context)
 	process_heredoc(tmp_parser, context, &status);
 	while (tmp_parser != NULL)
 	{
-		set_heredoc_signal_parent_handler();
+		set_heredoc_signal_handler();
 		if (tmp_parser->next != NULL)
 			pipe_check(&pipe_x, context, &status, pipe_x.current_cmd_num);
 		pipe_x.pids[pipe_x.current_cmd_num] = fork_check(context, &status);

--- a/src/signal/signal.c
+++ b/src/signal/signal.c
@@ -47,7 +47,7 @@ void set_heredoc_signal_handler()
     sa.sa_flags = SA_SIGINFO;
     sa.sa_handler = SIG_IGN;
     sigaction(SIGQUIT, &sa, NULL);
-    sa.sa_handler = SIG_DFL;
+    sa.sa_handler = heredoc_signal_handler;
     sigaction(SIGINT, &sa, NULL);
 }
 

--- a/src/signal/signal.c
+++ b/src/signal/signal.c
@@ -32,42 +32,24 @@ void    set_signal_child_handler()
     ft_memset(&sa, 0, sizeof(struct sigaction));
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_SIGINFO;
-    sa.sa_handler = SIG_DFL;
-    sigaction(SIGQUIT, &sa, NULL);
+    sa.sa_handler = heredoc_signal_handler;
     sigaction(SIGINT, &sa, NULL);
+    sa.sa_handler = SIG_IGN;
+    sigaction(SIGQUIT, &sa, NULL);
 }
 
-void    set_heredoc_signal_parent_handler()
+void set_heredoc_signal_handler()
 {
     struct sigaction sa;
 
     ft_memset(&sa, 0, sizeof(struct sigaction));
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_SIGINFO;
-    // SIGQUIT
     sa.sa_handler = SIG_IGN;
     sigaction(SIGQUIT, &sa, NULL);
-    // SIGINT
-    sa.sa_handler = heredoc_signal_parent_handler;
+    sa.sa_handler = SIG_DFL;
     sigaction(SIGINT, &sa, NULL);
-
 }
-
-//void    set_heredoc_signal_child_handler()
-//{
-//    struct sigaction sa;
-//
-//    ft_memset(&sa, 0, sizeof(struct sigaction));
-//    sigemptyset(&sa.sa_mask);
-//    sa.sa_flags = SA_SIGINFO;
-////    SIGQUIT
-//    sa.sa_handler = SIG_IGN;
-//    sigaction(SIGQUIT, &sa, NULL);
-////    SIGINT
-//    sa.sa_handler = SIG_DFL;
-//    sigaction(SIGINT, &sa, NULL);
-//}
-//
 
 void    signal_init(t_context *ctx)
 {
@@ -77,6 +59,3 @@ void    signal_init(t_context *ctx)
 
     set_signal_handler();
 }
-
-//ヒアドクの処理が親プロセスないで同期的におこなってるからsignal_heredoc_child_handlerはいらない
-//ー＞ヒアドクの処理中に発生するシグナルは親プロセスでハンドリングする

--- a/src/signal/signal_handler.c
+++ b/src/signal/signal_handler.c
@@ -38,6 +38,5 @@ void    heredoc_signal_handler(int signum)
     {
         g_signal = 1;
         ft_printf("\n");
-        // exit(1);
     }
 }

--- a/src/signal/signal_handler.c
+++ b/src/signal/signal_handler.c
@@ -32,12 +32,12 @@ void signal_parent_handler(int signum)
     }
 }
 
-void    heredoc_signal_parent_handler(int signum)
+void    heredoc_signal_handler(int signum)
 {
     if (signum == SIGINT)
     {
         g_signal = 1;
         ft_printf("\n");
-        exit(1);
+        // exit(1);
     }
 }


### PR DESCRIPTION
## 概要

builtinのexit実装

## 変更点

- 変更点1：exec_cmd, exec_minishell_builtinの引数にプロセス情報を引数として渡すように変更した
- 変更点2：exitを実装した
- 変更点3：minishell_no_pipeでのシグナルハンドラをヒアドク用のに間違えていたため、set_signal_parent_handlerに変更

## 影響範囲


## テスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- テストケース1：exit 42
minishell$ exit 42
exit
root@feb2b8c31fae:/app# echo $?
42

- テストケース2：exit
minishell$ exit
exit
root@feb2b8c31fae:/app# echo $?
0

- テストケース3：exit abc
minishell$ exit abc
exit
minishell: exit: abc: numeric argument required
root@feb2b8c31fae:/app# echo $?
255

- テストケース4：exit " 1 2 3"
minishell$ exit " 1 2 3"
exit
minishell: exit:  1 2 3: numeric argument required
root@feb2b8c31fae:/app# echo $?
255


🌟相談

・exit "  42    "　のようなコマンドに対応するか
　ここの対応はできてなくて、もしこれをちゃんとexit 42と同じようにするなら少し追加でコード書く
・long overflowが少し緩めなのできっちりやるか